### PR TITLE
Add wxflow as a submodule, preparing for the ctests that uses jcb

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -59,3 +59,6 @@
 [submodule "sorc/jcb"]
 	path = sorc/jcb
 	url = https://github.com/NOAA-EMC/jcb.git
+[submodule "sorc/wxflow"]
+	path = sorc/wxflow
+	url = https://github.com/NOAA-EMC/wxflow.git


### PR DESCRIPTION
The jcb scripts require `wxflow` as a python module, which will be called in the ctests