### PR TITLE
Remove Submodule IODACONV

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,10 +37,6 @@
 	path = sorc/fv3-jedi
 	url = https://github.com/jcsda/fv3-jedi.git
  	branch = develop
-[submodule "sorc/iodaconv"]
-	path = sorc/iodaconv
-	url = https://github.com/JCSDA-internal/ioda-converters.git
-        branch = develop
 [submodule "sorc/crtm"]
 	path = sorc/crtm
 	url = https://github.com/jcsda/crtm.git

--- a/build.sh
+++ b/build.sh
@@ -192,7 +192,7 @@ if [[ $BUILD_JCSDA == 'YES' ]]; then
   make -j ${BUILD_JOBS:-8} VERBOSE=$BUILD_VERBOSE
 else
   #builddirs="fv3-jedi iodaconv bufr-query da-utils"
-  builddirs="fv3-jedi bufr-query"
+  builddirs="fv3-jedi bufr-query da-utils"
   for b in $builddirs; do
     cd $b
     set +x      

--- a/bundle/CMakeLists.txt
+++ b/bundle/CMakeLists.txt
@@ -34,6 +34,7 @@ set( ENABLE_MPI ON CACHE BOOL "Compile with MPI" )
 # Handle user options.
 option(BUILD_HDASBUNDLE "Build HDAS Bundle" ON)
 option(CLONE_JCSDADATA "Clone JCSDA test data repositories" OFF)
+option(BUILD_IODA_CONVERTERS "Build IODA Converters" OFF)
 
 # Depend path for non-ecbuild packages
 set(DEPEND_LIB_ROOT ${CMAKE_CURRENT_BINARY_DIR}/Depends)
@@ -104,7 +105,6 @@ if(BUILD_HDASBUNDLE)
   ecbuild_bundle( PROJECT da-utils SOURCE "../sorc/da-utils" )
 
 # Build IODA converters
-  option(BUILD_IODA_CONVERTERS "Build IODA Converters" ON)
   if(BUILD_IODA_CONVERTERS)
     ecbuild_bundle( PROJECT iodaconv SOURCE "../sorc/iodaconv" )
   endif()


### PR DESCRIPTION
Remove submodule `iodaconv`
Update submodule `da-utils` 12e8e9...176068
This change will make sure the executable for satellite radiance bias correction related executables will still be kept.