### PR TITLE
Updated the Sondes Yamls 

### DIFF
--- a/hafs-test/IODA/bufrquery/bufr_air_raob.py
+++ b/hafs-test/IODA/bufrquery/bufr_air_raob.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+import os
+import sys
+import bufr
+import argparse
+import copy
+import math
+import calendar
+import time
+from datetime import datetime
+from bufr.bufr_python.encoders import *
+from bufr.encoders.netcdf import Encoder as netcdfEncoder
+from wxflow import Logger
+import numpy as np
+import numpy.ma as ma
+
+# Initialize Logger
+# Get log level from the environment variable, default to 'INFO it not set
+log_level = os.getenv('LOG_LEVEL', 'INFO')
+logger = Logger('bufr_air_raob.py', level=log_level, colored_log=False)
+
+
+def logging(comm, level, message):
+    """
+    Logs a message to the console or log file, based on the specified logging level.
+
+    This function ensures that logging is only performed by the root process (`rank 0`)
+    in a distributed computing environment. The function maps the logging level to
+    appropriate logger methods and defaults to the 'INFO' level if an invalid level is provided.
+
+    Parameters:
+        comm: object
+            The communicator object, typically from a distributed computing framework
+            (e.g., MPI). It must have a `rank()` method to determine the process rank.
+        level: str
+            The logging level as a string. Supported levels are:
+                - 'DEBUG'
+                - 'INFO'
+                - 'WARNING'
+                - 'ERROR'
+                - 'CRITICAL'
+            If an invalid level is provided, a warning will be logged, and the level
+            will default to 'INFO'.
+        message: str
+            The message to be logged.
+
+    Behavior:
+        - Logs messages only on the root process (`comm.rank() == 0`).
+        - Maps the provided logging level to a method of the logger object.
+        - Defaults to 'INFO' and logs a warning if an invalid logging level is given.
+        - Supports standard logging levels for granular control over log verbosity.
+
+    Example:
+        >>> logging(comm, 'DEBUG', 'This is a debug message.')
+        >>> logging(comm, 'ERROR', 'An error occurred!')
+
+    Notes:
+        - Ensure that a global `logger` object is configured before using this function.
+        - The `comm` object should conform to MPI-like conventions (e.g., `rank()` method).
+    """
+
+    if comm.rank() == 0:
+        # Define a dictionary to map levels to logger methods
+        log_methods = {
+            'DEBUG': logger.debug,
+            'INFO': logger.info,
+            'WARNING': logger.warning,
+            'ERROR': logger.error,
+            'CRITICAL': logger.critical,
+        }
+
+        # Get the appropriate logging method, default to 'INFO'
+        log_method = log_methods.get(level.upper(), logger.info)
+
+        if log_method == logger.info and level.upper() not in log_methods:
+            # Log a warning if the level is invalid
+            logger.warning(f'log level = {level}: not a valid level --> set to INFO')
+
+        # Call the logging method
+        log_method(message)
+
+
+def _compute_datetime(cycleTimeSinceEpoch, dhr):
+    """
+    Compute dateTime using the cycleTimeSinceEpoch and Cycle Time
+        minus Cycle Time
+
+    Parameters:
+        cycleTimeSinceEpoch: Time of cycle in Epoch Time
+        dhr: Observation Time Minus Cycle Time
+
+    Returns:
+        Masked array of dateTime values
+    """
+
+    int64_fill_value = np.int64(0)
+
+    dateTime = np.zeros(dhr.shape, dtype=np.int64)
+    for i in range(len(dateTime)):
+        if ma.is_masked(dhr[i]):
+            continue
+        else:
+            dateTime[i] = np.int64(dhr[i]*3600) + cycleTimeSinceEpoch
+
+    dateTime = ma.array(dateTime)
+    dateTime = ma.masked_values(dateTime, int64_fill_value)
+
+    return dateTime
+
+
+def _make_description(mapping_path, cycle_time, update=False):
+    description = bufr.encoders.Description(mapping_path)
+
+    ReferenceTime = np.int64(calendar.timegm(time.strptime(str(int(cycle_time)), '%Y%m%d%H')))
+
+    if update:
+        # Define the variables to be added in a list of dictionaries
+        variables = [
+            {
+                'name': 'ObsValue/stationPressure',
+                'source': 'variables/stationPressure',
+                'units': 'Pa',
+                'longName': 'Station Pressure',
+            },
+            {
+                'name': 'ObsError/stationPressure',
+                'source': 'variables/stationPressureError',
+                'units': 'Pa',
+                'longName': 'Station Pressure Error',
+            },
+            {
+                'name': 'QualityMarker/stationPressure',
+                'source': 'variables/stationPressureQualityMarker',
+                'units': '',
+                'longName': 'Station Pressure Quality Marker',
+            }
+        ]
+
+        # Loop through each variable and add it to the description
+        for var in variables:
+            description.add_variable(
+                name=var['name'],
+                source=var['source'],
+                units=var['units'],
+                longName=var['longName']
+            )
+
+        # description.add_global(name='datetimeReference', value=str(ReferenceTime))
+
+    return description
+
+
+def _make_obs(comm, input_path, mapping_path, cycle_time):
+    """
+    Create the ioda adpupa prepbufr observations:
+    - reads values
+    - adds sequenceNum
+
+    Parameters
+    ----------
+    comm: object
+            The communicator object (e.g., MPI)
+    input_path: str
+            The input bufr file
+    mapping_path: str
+            The input bufr2ioda mapping file
+    cycle_time: str
+            The cycle in YYYYMMDDHH format
+    """
+
+    # Get container from mapping file first
+    logging(comm, 'INFO', 'Get container from bufr')
+    container = bufr.Parser(input_path, mapping_path).parse(comm)
+
+    logging(comm, 'DEBUG', f'container list (original): {container.list()}')
+    logging(comm, 'DEBUG', f'prepbufrDataLevelCategory')
+    cat = container.get('variables/prepbufrDataLevelCategory')
+
+    logging(comm, 'DEBUG', f'Change longitude range from [0,360] to [-180,180]')
+    lon = container.get('variables/longitude')
+    lon_paths = container.get_paths('variables/longitude')
+    lon[lon > 180] -= 360
+    lon = ma.round(lon, decimals=2)
+    logging(comm, 'DEBUG', f'longitude max and min are {lon.max()}, {lon.min()}')
+
+    logging(comm, 'DEBUG', f'Do DateTime calculation')
+    otmct = container.get('variables/timeOffset')
+    otmct_paths = container.get_paths('variables/timeOffset')
+    otmct2 = np.array(otmct)
+    cycleTimeSinceEpoch = np.int64(calendar.timegm(time.strptime(str(int(cycle_time)), '%Y%m%d%H')))
+    dateTime = _compute_datetime(cycleTimeSinceEpoch, otmct2)
+    min_dateTime_ge_zero = min(x for x in dateTime if x > -1)
+    logging(comm, 'DEBUG', f'dateTime min/max = {min_dateTime_ge_zero} {dateTime.max()}')
+
+    logging(comm, 'DEBUG', f'Make an array of 0s for MetaData/sequenceNumber')
+    sequenceNum = np.zeros(lon.shape, dtype=np.int32)
+    logging(comm, 'DEBUG', f' sequenceNummin/max =  {sequenceNum.min()} {sequenceNum.max()}')
+    logging(comm, 'DEBUG', f'Do ps calculation')
+    pob = container.get('variables/pressure')
+    ps = np.full(pob.shape[0], pob.fill_value)
+    ps = np.where(cat == 0, pob, ps)
+
+    logging(comm, 'DEBUG', f'Do tsen and tv calculation')
+    tpc = container.get('variables/temperatureEventCode')
+    tob = container.get('variables/airTemperature')
+    tsen = np.full(tob.shape[0], tob.fill_value)
+    tsen = np.where(((tpc >=1) & (tpc < 8)), tob, tsen)
+    tvo = np.full(tob.shape[0], tob.fill_value)
+    tvo = np.where((tpc == 8), tob, tvo)
+
+    logging(comm, 'DEBUG', f'Do ps QM calculations')
+    pqm = container.get('variables/pressureQualityMarker')
+    psqm = np.full(pqm.shape[0], pqm.fill_value)
+    psqm = np.where(cat == 0, pqm, psqm)
+
+    logging(comm, 'DEBUG', f'Do tsen and tv QM calculations')
+    tobqm = container.get('variables/airTemperatureQualityMarker')
+    tsenqm = np.full(tobqm.shape[0], tobqm.fill_value)
+    tsenqm = np.where(((tpc >= 1) & (tpc < 8)), tobqm, tsenqm)
+    tvoqm = np.full(tobqm.shape[0], tobqm.fill_value)
+    tvoqm = np.where((tpc == 8), tobqm, tvoqm)
+
+    logging(comm, 'DEBUG', f'Do ps ObsError calculations')
+    poe = container.get('variables/pressureError')
+    psoe = np.full(poe.shape[0], poe.fill_value)
+    psoe = np.where(cat == 0, poe, psoe)
+
+    logging(comm, 'DEBUG', f'Do tsen and tv ObsError calculations')
+    toboe = container.get('variables/airTemperatureError')
+    tsenoe = np.full(toboe.shape[0], toboe.fill_value)
+    tsenoe = np.where(((tpc >= 1) & (tpc < 8)), toboe, tsenoe)
+    tvooe = np.full(toboe.shape[0], toboe.fill_value)
+    tvooe = np.where((tpc == 8), toboe, tvooe)
+
+    logging(comm, 'DEBUG', f'Update variables in container')
+    container.replace('variables/longitude', lon)
+    container.replace('variables/timestamp', dateTime)
+    container.replace('variables/airTemperature', tsen)
+    container.replace('variables/airTemperatureQualityMarker', tsenqm)
+    container.replace('variables/airTemperatureError', tsenoe)
+    container.replace('variables/virtualTemperature', tvo)
+    container.replace('variables/virtualTemperatureQualityMarker', tvoqm)
+    container.replace('variables/virtualTemperatureError', tvooe)
+
+    logging(comm, 'DEBUG', f'Add variables to container')
+    container.add('variables/sequenceNumber', sequenceNum, lon_paths)
+
+    container.add('variables/stationPressure', ps, lon_paths)
+    container.add('variables/stationPressureQualityMarker', psqm, lon_paths)
+    container.add('variables/stationPressureError', psoe, lon_paths)
+
+    # Check
+    logging(comm, 'DEBUG', f'container list (updated): {container.list()}')
+
+    return container
+
+
+def create_obs_group(input_path, mapping_path, cycle_time, env):
+
+    comm = bufr.mpi.Comm(env["comm_name"])
+
+    logging(comm, 'INFO', f'Make description and make obs')
+
+    container = _make_obs(comm, input_path, mapping_path, cycle_time)
+    description = _make_description(mapping_path, cycle_time, update=True)
+
+    # Gather data from all tasks into all tasks. Each task will have the complete record
+    logging(comm, 'INFO', f'Gather data from all tasks into all tasks')
+    container.all_gather(comm)
+
+    logging(comm, 'INFO', f'Encode the data')
+    data = next(iter(iodaEncoder(description).encode(container).values()))
+
+    logging(comm, 'INFO', f'Return the encoded data.')
+
+    return data
+
+
+def create_obs_file(input_path, mapping_path, output_path, cycle_time):
+
+    comm = bufr.mpi.Comm("world")
+    container = _make_obs(comm, input_path, mapping_path, cycle_time)
+    container.gather(comm)
+
+    description = _make_description(mapping_path, cycle_time, update=True)
+
+    # Encode the data
+    if comm.rank() == 0:
+        netcdfEncoder(description).encode(container, output_path)
+
+    logging(comm, 'INFO', f'Return the encoded data')
+
+
+if __name__ == '__main__':
+    start_time = time.time()
+
+    bufr.mpi.App(sys.argv)
+    comm = bufr.mpi.Comm("world")
+
+    # Required input arguments as positional arguments
+    parser = argparse.ArgumentParser(description="Convert BUFR to NetCDF using a mapping file.")
+    parser.add_argument('input', type=str, help='Input BUFR file')
+    parser.add_argument('mapping', type=str, help='BUFR2IODA Mapping File')
+    parser.add_argument('output', type=str, help='Output NetCDF file')
+    parser.add_argument('cycle_time', type=str, help='cycle time in YYYYMMDDHH format')
+
+    args = parser.parse_args()
+    infile = args.input
+    mapping = args.mapping
+    output = args.output
+    cycle_time = args.cycle_time
+
+    create_obs_file(infile, mapping, output, cycle_time)
+
+    end_time = time.time()
+    running_time = end_time - start_time
+    logging(comm, 'INFO', f'Total running time: {running_time}')

--- a/hafs-test/IODA/bufrquery/bufr_air_raob_mapping.yaml
+++ b/hafs-test/IODA/bufrquery/bufr_air_raob_mapping.yaml
@@ -1,0 +1,376 @@
+# (C) Copyright 2024 NOAA/NWS/NCEP/EMC
+
+bufr:
+  group_by_variable: prepbufrDataLevelCategory
+  subsets:
+    - ADPUPA
+  variables:
+    # ObsType
+    observationType:
+      query: "*/TYP"
+
+    # MetaData
+    timestamp:
+      timeoffset:
+        timeOffset: "*/PRSLEVEL/DRFTINFO/HRDR"
+        transforms:
+          - scale: 3600
+        referenceTime: #ANADATE#
+    timeOffset:
+      query: "*/DHR"
+
+    prepbufrDataLevelCategory:
+      query: "*/PRSLEVEL/CAT"
+
+    dumpReportType:
+      query: "*/T29"
+
+    longitude:
+      query: "*/PRSLEVEL/DRFTINFO/XDR"
+
+    latitude:
+      query: "*/PRSLEVEL/DRFTINFO/YDR"
+
+    stationIdentification:
+      query: "*/SID"
+
+    stationElevation:
+      query: "*/ELV"
+
+    temperatureEventCode:
+      query: "*/PRSLEVEL/T___INFO/T__EVENT{1}/TPC"    
+
+    pressure:
+      query: "*/PRSLEVEL/P___INFO/P__EVENT{1}/POB"
+      type: float
+      transforms:
+        - scale: 100
+
+    height:
+      query: "*/PRSLEVEL/Z___INFO/Z__EVENT{1}/ZOB"
+      type: float
+        
+    # ObsValue
+    airTemperature:
+      query: "*/PRSLEVEL/T___INFO/T__EVENT{1}/TOB"
+      transforms:
+        - offset: 273.15
+
+    dewPointTemperature:
+      query: "*/PRSLEVEL/Q___INFO/TDO"
+      transforms:
+        - offset: 273.15
+
+    virtualTemperature:
+      query: "*/PRSLEVEL/T___INFO/TVO"
+      transforms:
+        - offset: 273.15
+
+    windEastward:
+      query: "*/PRSLEVEL/W___INFO/W__EVENT{1}/UOB"
+
+    windNorthward:
+      query: "*/PRSLEVEL/W___INFO/W__EVENT{1}/VOB"
+
+    specificHumidity:
+      query: "*/PRSLEVEL/Q___INFO/Q__EVENT{1}/QOB"
+      type: float
+      transforms:
+        - scale: 0.000001
+
+    # QualityMark 
+    pressureQualityMarker:
+      query: "*/PRSLEVEL/P___INFO/P__EVENT{1}/PQM"
+
+    heightQualityMarker:
+      query: "*/PRSLEVEL/Z___INFO/Z__EVENT{1}/ZQM"
+
+    airTemperatureQualityMarker:
+      query: "*/PRSLEVEL/T___INFO/T__EVENT{1}/TQM"
+
+    virtualTemperatureQualityMarker:
+      query: "*/PRSLEVEL/T___INFO/T__EVENT{1}/TQM"
+
+    windQualityMarker:
+      query: "*/PRSLEVEL/W___INFO/W__EVENT{1}/WQM"
+
+    specificHumidityQualityMarker:
+      query: "*/PRSLEVEL/Q___INFO/Q__EVENT{1}/QQM"
+
+    # ObsError
+    pressureError:
+      query: "*/PRSLEVEL/P___INFO/P__BACKG/POE"
+      transforms:
+        - scale: 100
+
+    airTemperatureError:
+      query: "*/PRSLEVEL/T___INFO/T__BACKG/TOE"
+      transforms:
+        - offset: 273.15
+
+    virtualTemperatureError:
+      query: "*/PRSLEVEL/T___INFO/T__BACKG/TOE"
+      transforms:
+        - offset: 273.15
+
+    windError:
+      query: "*/PRSLEVEL/W___INFO/W__BACKG/WOE"
+
+    specificHumidityError:
+      query: "*/PRSLEVEL/Q___INFO/Q__BACKG/QOE"
+
+
+encoder:
+  type: netcdf
+
+  globals:
+    - name: "data_format"
+      type: string
+      value: "prepbufr"
+
+    - name: "data_type"
+      type: string
+      value: "ADPUPA"
+
+    - name: "subsets"
+      type: string
+      value: "ADPUPA"        
+
+    - name: "data_provider"
+      type: string
+      value: "U.S. NOAA"
+
+    - name: "data_description"
+      type: string
+      value: "UPPER-AIR (RAOB, PIBAL, RECCO, DROPS) REPORTS"
+
+
+  variables:
+    # Observation Type: Pressure
+    - name: "ObsType/stationPressure"
+      source: variables/observationType
+      longName: "Observation Type"
+
+    # Observation Type: airTemperature
+    - name: "ObsType/airTemperature"
+      source: variables/observationType
+      longName: "Observation Type"
+
+    # Observation Type: virtualTemperature
+    - name: "ObsType/virtualTemperature"
+      source: variables/observationType
+      longName: "Observation Type"
+
+    # Observation Type: windEastward    
+    - name: "ObsType/windEastward"
+      source: variables/observationType
+      longName: "Observation Type"
+
+    # Observation Type: windNorthward     
+    - name: "ObsType/windNorthward"
+      source: variables/observationType
+      longName: "Observation Type"
+
+    # Observation Type: specificHumidity
+    - name: "ObsType/specificHumidity"
+      source: variables/observationType
+      longName: "Observation Type"
+
+    # MetaData: dateTime
+    - name: "MetaData/dateTime"
+      coordinates: "longitude latitude"
+      source: variables/timestamp
+      longName: "ObservationTime"
+      units: "seconds since 1970-01-01T00:00:00Z"
+    
+    # MetaData: timeOffset
+    - name: "MetaData/timeOffset"
+      coordinates: "longitude latitude"
+      source: variables/timeOffset
+      longName: "Observation Time Minus Reference Time"
+      units: "s"
+
+    # MetaData: stationIdentification     
+    - name: "MetaData/stationIdentification"
+      coordinates: "longitude latitude"
+      source: variables/stationIdentification
+      longName: "Station ID"
+
+    # MetaData: longitude
+    - name: "MetaData/longitude"
+      coordinates: "longitude latitude"
+      source: variables/longitude
+      longName: "Longitude"
+      units: "degrees_east"
+      range: [-180, 180]
+
+    # MetaData: latitude    
+    - name: "MetaData/latitude"
+      coordinates: "longitude latitude"
+      source: variables/latitude
+      longName: "Latitude"
+      units: "degrees_north"
+      range: [-90, 90]
+
+    # MetaData: stationElevation    
+    - name: "MetaData/stationElevation"
+      coordinates: "longitude latitude"
+      source: variables/stationElevation
+      longName: "Height of Station"
+      units: "m"
+
+    # MetaData: prepbufrDataLevelCategory
+    - name: "MetaData/prepbufrDataLevelCategory"
+      coordinates: "longitude latitude"
+      source: variables/prepbufrDataLevelCategory
+      longName: "Prepbufr Data Level Category"
+
+    # MetaData: temperatureEventCode
+    - name: "MetaData/temperatureEventCode"
+      source: variables/temperatureEventCode
+      longName: "Temperature Event Program Code"
+
+    # MetaData: pressure
+    - name: "MetaData/pressure"
+      coordinates: "longitude latitude"
+      source: variables/pressure
+      longName: "Pressure"
+      units: "Pa"
+
+    # MetaData: height
+    - name: "MetaData/height"
+      coordinates: "longitude latitude"
+      source: variables/height
+      longName: "Height of Observation"
+      units: "m"
+
+    # ObsValue: Pressure
+    - name: "ObsValue/Pressure"
+      source: variables/pressure
+      longName: "Station Pressure"
+      units: "Pa"
+
+    # ObsValue: airTemperature
+    - name: "ObsValue/airTemperature"
+      coordinates: "longitude latitude"
+      source: variables/airTemperature
+      longName: "Temperature"
+      units: "K"
+
+    # ObsValue: dewPointTemperature
+    - name: "ObsValue/dewPointTemperature"
+      coordinates: "longitude latitude"
+      source: variables/dewPointTemperature
+      longName: "DewPoint Temperature"
+      units: "K"
+
+    # ObsValue: virtualTemperature
+    - name: "ObsValue/virtualTemperature"
+      coordinates: "longitude latitude"
+      source: variables/virtualTemperature
+      longName: "Virtual Temperature Non-Q Controlled"
+      units: "K"
+
+    # ObsValue: windEastward
+    - name: "ObsValue/windEastward"
+      coordinates: "longitude latitude"
+      source: variables/windEastward
+      longName: "Eastward Wind"
+      units: "m s-1"
+
+    # ObsValue: windNorthward
+    - name: "ObsValue/windNorthward"
+      coordinates: "longitude latitude"
+      source: variables/windNorthward
+      longName: "Northward Wind"
+      units: "m s-1"
+
+    # ObsValue: specificHumidity
+    - name: "ObsValue/specificHumidity"
+      coordinates: "longitude latitude"
+      source: variables/specificHumidity
+      longName: "Specific Humidity"
+      units: "kg kg-1"
+
+    # QualityMarker: height
+    - name: "QualityMarker/height"
+      coordinates: "longitude latitude"
+      source: variables/heightQualityMarker
+      longName: "Height Quality Marker"
+
+    # QualityMarker: Pressure
+    - name: "QualityMarker/Pressure"
+      coordinates: "longitude latitude"
+      source: variables/pressureQualityMarker
+      longName: "Pressure Quality Marker"
+
+    # QualityMarker: airTemperature
+    - name: "QualityMarker/airTemperature"
+      coordinates: "longitude latitude"
+      source: variables/airTemperatureQualityMarker
+      longName: "Temperature Quality Marker"
+
+    # QualityMarker: virtualTemperature
+    - name: "QualityMarker/virtualTemperature"
+      coordinates: "longitude latitude"
+      source: variables/virtualTemperatureQualityMarker
+      longName: "Virtual Temperature Quality Marker"
+
+    # QualityMarker: windEastward
+    - name: "QualityMarker/windEastward"
+      coordinates: "longitude latitude"
+      source: variables/windQualityMarker
+      longName: "Eastward Wind Quality Marker"
+
+    # QualityMarker: windNorthward
+    - name: "QualityMarker/windNorthward"
+      coordinates: "longitude latitude"
+      source: variables/windQualityMarker
+      longName: "Northward Wind Quality Marker"
+
+    # QualityMarker: specificHumidity
+    - name: "QualityMarker/specificHumidity"
+      coordinates: "longitude latitude"
+      source: variables/specificHumidityQualityMarker
+      longName: "Specific Humidity Quality Marker"
+
+    # ObsError: pressure 
+    - name: "ObsError/pressure"
+      coordinates: "longitude latitude"
+      source: variables/pressureError
+      longName: "Pressure Error"
+      units: "Pa"
+
+    # ObsError: airTemperature
+    - name: "ObsError/airTemperature"
+      coordinates: "longitude latitude"
+      source: variables/airTemperatureError
+      longName: "Temperature Error"
+      units: "K"
+
+    # ObsError: virtualTemperature
+    - name: "ObsError/virtualTemperature"
+      coordinates: "longitude latitude"
+      source: variables/airTemperatureError
+      longName: "Virtual Temperature Error"
+      units: "K"
+
+    # ObsError: windEastward
+    - name: "ObsError/windEastward"
+      coordinates: "longitude latitude"
+      source: variables/windError
+      longName: "East Wind Error"
+      units: "m s-1"
+
+    # ObsError: windNorthward
+    - name: "ObsError/windNorthward"
+      coordinates: "longitude latitude"
+      source: variables/windError
+      longName: "North Wind Error"
+      units: "m s-1"
+
+    # ObsError: specificHumidity
+    - name: "ObsError/specificHumidity"
+      coordinates: "longitude latitude"
+      source: variables/specificHumidityError
+      longName: "Specific Humidity Error"

--- a/hafs-test/IODA/bufrquery/bufr_ascatw.py
+++ b/hafs-test/IODA/bufrquery/bufr_ascatw.py
@@ -8,7 +8,7 @@ import bufr
 from bufr.obs_builder import ObsBuilder, add_main_functions, map_path, add_dummy_variable
 
 
-MAPPING_PATH = map_path('prepbufr_ascatw.yaml')
+MAPPING_PATH = map_path('bufr_ascatw.yaml')
 
 
 class AscatwPrepbufrObsBuilder(ObsBuilder):

--- a/parm/jcb-hdas/observations/atmosphere/conventional_air_raob_120ps.yaml.j2
+++ b/parm/jcb-hdas/observations/atmosphere/conventional_air_raob_120ps.yaml.j2
@@ -1,269 +1,269 @@
-    - obs space:
-        name: adpupa_stationPressure_120
-        obsdatain:
-          engine:
-            type: H5File
-            obsfile: obs/hafs.t{{HH}}z.conventional_air_raob.nc
-            missing file action: warn
-          obsgrouping:
-            group variables:
-            - stationIdentification
-            sort variable: pressure
-            sort order: descending
-        obsdataout:
-          engine:
-            type: H5File
-            obsfile: hofx/diag_conventional_air_raobps_t{{HH}}z.nc
-            allow overwrite: true
-        io pool:
-          max pool size: {{TOTAL_TASKS}}
-        observed variables: [stationPressure]
-        simulated variables: [stationPressure]
-
-      obs operator:
-        name: SfcCorrected
-        variables:
-        - name: stationPressure
-        correction scheme to use: GSL
-        station_altitude: height
-        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
-        geovar_geomz: geopotential_height
-
-      linear obs operator:
-        name: Identity
-        variables:
-        - name: stationPressure
-
-      obs error:
-        covariance model: diagonal
-
-      obs pre filters:
-      - filter: Domain Check
-        apply at iterations: 0, 1
-        where:
-        - variable:
-            name: MetaData/latitude
-          minvalue: {{MIN_LAT}}
-          maxvalue: {{MAX_LAT}}
-        action:
-          name: reduce obs space
-      - filter: Domain Check
-        apply at iterations: 0, 1
-        where:
-        - variable:
-            name: MetaData/longitude
-          minvalue: {{MIN_LON}}
-          maxvalue: {{MAX_LON}}
-        action:
-          name: reduce obs space
-      # Reject all obs with QualityMarker > 3
-      - filter: RejectList
-        apply at iterations: 0,1
-        filter variables:
-        - name: stationPressure
-        where:
-        - variable: ObsType/stationPressure
-          is_not_in: 120
-        - variable: QualityMarker/stationPressure
-          is_in: 4-15
-          value: is_not_valid
-        - variable: MetaData/pressure
-          value: is_not_valid
-        where operator: or
-        action:
-          name: reduce obs space
-
-      obs prior filters:
-      - filter: Bounds Check
-        filter variables:
-        - name: stationPressure
-        test variables:
-        - name: GeoVaLs/observable_domain_mask
-          flag all filter variables if any test variable is out of bounds: true
-          minvalue: 0.0
-          maxvalue: 0.5
-
-      - filter: Perform Action
-        filter variables:
-        - name: stationPressure
-        where:
-        - variable: ObsType/stationPressure
-          is_in: 120
-        action:
-          name: assign error
-          error function:
-            name: ObsFunction/ObsErrorModelStepwiseLinear
-            options:
-              xvar:
-                name: ObsValue/stationPressure
-              xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
-              errors: [76.322, 76.322, 76.322, 79.899, 83.56099999999999, 87.224, 89.405, 91.58500000000001, 93.767, 103.58000000000001, 113.38999999999999, 122.12, 131.94, 143.91, 162.46, 177.69, 204.97, 276.94, 302.02, 353.27000000000004, 429.57, 548.4399999999999, 646.55, 646.55, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0]
-      # Create PreQC group Variable
-      - filter: Variable Assignment
-        assignments:
-        - name: InputObsError/stationPressure
-          type: float
-          source variable: ObsError/stationPressure
-
-      # Create PreUseFlag Group Variable
-      - filter: Variable Assignment
-        assignments:
-        - name: PreUseFlag/stationPressure
-          type: int
-          source variable: QualityMarker/stationPressure
-      - filter: Variable Assignment
-        where:
-        - variable:
-            name: PreUseFlag/stationPressure
-          is_in: 1-15
-        assignments:
-        - name: PreUseFlag/stationPressure
-          value: 0
-      - filter: Variable Assignment
-        where:
-        - variable:
-            name: ObsValue/stationPressure
-          is_defined: null
-        - variable:
-            name: ObsValue/stationPressure
-          maxvalue: 50000.0
-        where operator: and
-        assignments:
-        - name: PreUseFlag/stationPressure
-          value: 100
-      - filter: Variable Assignment
-        where:
-        - variable:
-            name: QualityMarker/stationPressure
-          is_in: 9, 12, 15
-        assignments:
-        - name: PreUseFlag/stationPressure
-          value: 100
-      - filter: Variable Assignment
-        where:
-        - variable:
-            name: QualityMarker/stationPressure
-          is_in: 4-15
-        assignments:
-        - name: PreUseFlag/stationPressure
-          value: 101
-      # Inflate obs error based on obs type
-      - filter: Perform Action
-        filter variables:
-        - name: stationPressure
-        action:
-          name: inflate error
-          inflation factor: 1.2
-        where:
-        - variable: QualityMarker/stationPressure
-          is_in: 3, 7
-
-      # Observation Post Filters (QC)
-      # ----------------------------------------
-      obs post filters:
-      # Calculate the obs error inflation factors for duplicated observations at the same location
-      - filter: Variable Assignment
-        assignments:
-        - name: ObsErrorFactorDuplicateCheck/stationPressure
-          type: float
-          function:
-            name: ObsFunction/ObsErrorFactorDuplicateCheck
-            options:
-              use_air_pressure: false
-              variable: stationPressure
-      # Inflate surface pressure observation based on discrepancies between model and observations due to terrain
-      - filter: Perform Action
-        filter variables:
-        - name: stationPressure
-        where:
-        - variable: ObsType/airTemperature
-          is_in: 120
-        action:
-          name: inflate error
-          inflation variable:
-            name: ObsFunction/ObsErrorFactorSfcPressure
-            options:
-              geovar_sfc_geomz: height_above_mean_sea_level_at_surface
-              geovar_geomz: geopotential_height
-              station_altitude: height
-
-      - filter: Variable Assignment
-        assignments:
-        - name: DerivedMetaData/Innovation
-          type: float
-          function:
-            name: ObsFunction/Arithmetic
-            options:
-              variables:
-              - name: ObsValue/stationPressure
-              - name: HofX/stationPressure
-              coefs:
-              - 1
-              - -1
-      - filter: Variable Assignment
-        assignments:
-        - name: DerivedMetaData/ObsErrorBoundSfcPressure1
-          type: float
-          function:
-            name: ObsFunction/ObsErrorBoundConventional
-            options:
-              obsvar: stationPressure
-              obserr_bound_min: 100
-              obserr_bound_max: 300
-              obserr_bound_factor: 4.0
-
-      - filter: Background Check
-        filter variables:
-        - name: stationPressure
-        where:
-        - variable: QualityMarker/stationPressure
-          is_not_in: 3
-          value: is_not_valid
-        where operator: or
-        function absolute threshold:
-        - name: DerivedMetaData/ObsErrorBoundSfcPressure1
-        action:
-          name: reject
-      - filter: Variable Assignment
-        assignments:
-        - name: DerivedMetaData/ObsErrorBoundSfcPressure2
-          type: float
-          function:
-            name: ObsFunction/ObsErrorBoundConventional
-            options:
-              obsvar: stationPressure
-              obserr_bound_min: 100
-              obserr_bound_max: 300
-              obserr_bound_factor: 2.8
-
-      - filter: Background Check
-        filter variables:
-        - name: stationPressure
-        where:
-        - variable: QualityMarker/stationPressure
-          is_in: 3
-          value: is_not_valid
-        where operator: or
-        function absolute threshold:
-        - name: DerivedMetaData/ObsErrorBoundSfcPressure2
-        action:
-          name: reject
-      # Inflate obs error based on duplicate check
-      - filter: Perform Action
-        filter variables:
-        - name: stationPressure
-        action:
-          name: inflate error
-          inflation variable:
-            name: ObsErrorFactorDuplicateCheck/stationPressure
-      - filter: Perform Action
-        filter variables:
-        - name: stationPressure
-        where:
-        - variable: PreUseFlag/stationPressure
-          is_not_in: 0, 1
-          value: is_not_valid
-        where operator: or
-        action:
-          name: reject
-
+     - obs space:
+         name: adpupa_stationPressure_120
+         obsdatain:
+           engine:
+             type: H5File
+             obsfile: obs/hafs.t{{HH}}z.conventional_air_raob.nc
+             missing file action: warn
+           obsgrouping:
+             group variables:
+             - stationIdentification
+             sort variable: pressure
+             sort order: descending
+         obsdataout:
+           engine:
+             type: H5File
+             obsfile: hofx/diag_conventional_air_raobps_t{{HH}}z.nc
+             allow overwrite: true
+         io pool:
+           max pool size: {{TOTAL_TASKS}}
+         observed variables: [stationPressure]
+         simulated variables: [stationPressure]
+ 
+       obs operator:
+         name: SfcCorrected
+         variables:
+         - name: stationPressure
+         correction scheme to use: GSL
+         station_altitude: height
+         geovar_sfc_geomz: height_above_mean_sea_level_at_surface
+         geovar_geomz: geopotential_height
+ 
+       linear obs operator:
+         name: Identity
+         variables:
+         - name: stationPressure
+ 
+       obs error:
+         covariance model: diagonal
+ 
+       obs pre filters:
+       - filter: Domain Check
+         apply at iterations: 0, 1
+         where:
+         - variable:
+             name: MetaData/latitude
+           minvalue: {{MIN_LAT}}
+           maxvalue: {{MAX_LAT}}
+         action:
+           name: reduce obs space
+       - filter: Domain Check
+         apply at iterations: 0, 1
+         where:
+         - variable:
+             name: MetaData/longitude
+           minvalue: {{MIN_LON}}
+           maxvalue: {{MAX_LON}}
+         action:
+           name: reduce obs space
+       # Reject all obs with QualityMarker > 3
+       - filter: RejectList
+         apply at iterations: 0,1
+         filter variables:
+         - name: stationPressure
+         where:
+         - variable: ObsType/stationPressure
+           is_not_in: 120
+         - variable: QualityMarker/stationPressure
+           is_in: 4-15
+           value: is_not_valid
+         - variable: MetaData/pressure
+           value: is_not_valid
+         where operator: or
+         action:
+           name: reduce obs space
+ 
+       obs prior filters:
+       - filter: Bounds Check
+         filter variables:
+         - name: stationPressure
+         test variables:
+         - name: GeoVaLs/observable_domain_mask
+           flag all filter variables if any test variable is out of bounds: true
+           minvalue: 0.0
+           maxvalue: 0.5
+ 
+       - filter: Perform Action
+         filter variables:
+         - name: stationPressure
+         where:
+         - variable: ObsType/stationPressure
+           is_in: 120
+         action:
+           name: assign error
+           error function:
+             name: ObsFunction/ObsErrorModelStepwiseLinear
+             options:
+               xvar:
+                 name: ObsValue/stationPressure
+               xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
+               errors: [76.322, 76.322, 76.322, 79.899, 83.56099999999999, 87.224, 89.405, 91.58500000000001, 93.767, 103.58000000000001, 113.38999999999999, 122.12, 131.94, 143.91, 162.46, 177.69, 204.97, 276.94, 302.02, 353.27000000000004, 429.57, 548.4399999999999, 646.55, 646.55, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0]
+       # Create PreQC group Variable
+       - filter: Variable Assignment
+         assignments:
+         - name: InputObsError/stationPressure
+           type: float
+           source variable: ObsError/stationPressure
+ 
+       # Create PreUseFlag Group Variable
+       - filter: Variable Assignment
+         assignments:
+         - name: PreUseFlag/stationPressure
+           type: int
+           source variable: QualityMarker/stationPressure
+       - filter: Variable Assignment
+         where:
+         - variable:
+             name: PreUseFlag/stationPressure
+           is_in: 1-15
+         assignments:
+         - name: PreUseFlag/stationPressure
+           value: 0
+       - filter: Variable Assignment
+         where:
+         - variable:
+             name: ObsValue/stationPressure
+           is_defined: null
+         - variable:
+             name: ObsValue/stationPressure
+           maxvalue: 50000.0
+         where operator: and
+         assignments:
+         - name: PreUseFlag/stationPressure
+           value: 100
+       - filter: Variable Assignment
+         where:
+         - variable:
+             name: QualityMarker/stationPressure
+           is_in: 9, 12, 15
+         assignments:
+         - name: PreUseFlag/stationPressure
+           value: 100
+       - filter: Variable Assignment
+         where:
+         - variable:
+             name: QualityMarker/stationPressure
+           is_in: 4-15
+         assignments:
+         - name: PreUseFlag/stationPressure
+           value: 101
+       # Inflate obs error based on obs type
+       - filter: Perform Action
+         filter variables:
+         - name: stationPressure
+         action:
+           name: inflate error
+           inflation factor: 1.2
+         where:
+         - variable: QualityMarker/stationPressure
+           is_in: 3, 7
+ 
+       # Observation Post Filters (QC)
+       # ----------------------------------------
+       obs post filters:
+       # Calculate the obs error inflation factors for duplicated observations at the same location
+       - filter: Variable Assignment
+         assignments:
+         - name: ObsErrorFactorDuplicateCheck/stationPressure
+           type: float
+           function:
+             name: ObsFunction/ObsErrorFactorDuplicateCheck
+             options:
+               use_air_pressure: false
+               variable: stationPressure
+       # Inflate surface pressure observation based on discrepancies between model and observations due to terrain
+       - filter: Perform Action
+         filter variables:
+         - name: stationPressure
+         where:
+         - variable: ObsType/airTemperature
+           is_in: 120
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsFunction/ObsErrorFactorSfcPressure
+             options:
+               geovar_sfc_geomz: height_above_mean_sea_level_at_surface
+               geovar_geomz: geopotential_height
+               station_altitude: height
+ 
+       - filter: Variable Assignment
+         assignments:
+         - name: DerivedMetaData/Innovation
+           type: float
+           function:
+             name: ObsFunction/Arithmetic
+             options:
+               variables:
+               - name: ObsValue/stationPressure
+               - name: HofX/stationPressure
+               coefs:
+               - 1
+               - -1
+       - filter: Variable Assignment
+         assignments:
+         - name: DerivedMetaData/ObsErrorBoundSfcPressure1
+           type: float
+           function:
+             name: ObsFunction/ObsErrorBoundConventional
+             options:
+               obsvar: stationPressure
+               obserr_bound_min: 100
+               obserr_bound_max: 300
+               obserr_bound_factor: 4.0
+ 
+       - filter: Background Check
+         filter variables:
+         - name: stationPressure
+         where:
+         - variable: QualityMarker/stationPressure
+           is_not_in: 3
+           value: is_not_valid
+         where operator: or
+         function absolute threshold:
+         - name: DerivedMetaData/ObsErrorBoundSfcPressure1
+         action:
+           name: reject
+       - filter: Variable Assignment
+         assignments:
+         - name: DerivedMetaData/ObsErrorBoundSfcPressure2
+           type: float
+           function:
+             name: ObsFunction/ObsErrorBoundConventional
+             options:
+               obsvar: stationPressure
+               obserr_bound_min: 100
+               obserr_bound_max: 300
+               obserr_bound_factor: 2.8
+ 
+       - filter: Background Check
+         filter variables:
+         - name: stationPressure
+         where:
+         - variable: QualityMarker/stationPressure
+           is_in: 3
+           value: is_not_valid
+         where operator: or
+         function absolute threshold:
+         - name: DerivedMetaData/ObsErrorBoundSfcPressure2
+         action:
+           name: reject
+       # Inflate obs error based on duplicate check
+       - filter: Perform Action
+         filter variables:
+         - name: stationPressure
+         action:
+           name: inflate error
+           inflation variable:
+             name: ObsErrorFactorDuplicateCheck/stationPressure
+       - filter: Perform Action
+         filter variables:
+         - name: stationPressure
+         where:
+         - variable: PreUseFlag/stationPressure
+           is_not_in: 0, 1
+           value: is_not_valid
+         where operator: or
+         action:
+           name: reject
+ 

--- a/parm/jcb-hdas/observations/atmosphere/conventional_air_raob_120ps.yaml.j2
+++ b/parm/jcb-hdas/observations/atmosphere/conventional_air_raob_120ps.yaml.j2
@@ -1,176 +1,269 @@
-     - obs space:
-         name: apdupa
-         obsdatain:
-           engine:
-             type: H5File
-             obsfile: obs/hafs.t{{HH}}z.conventional_air_raob.nc
-             missing file action: "warn"
-         obsdataout:
-           engine:
-             type: H5File
-             obsfile: hofx/diag_conventional_air_raobps_t{{HH}}z.nc
-             allow overwrite: true
-         io pool:
-           max pool size: {{TOTAL_TASKS}}
-         observed variables: [stationPressure]
-         simulated variables: [stationPressure]
- 
-       obs operator:
-         name: SfcPCorrected
-         da_psfc_scheme: GSI
-         geovar_sfc_geomz: surface_geopotential_height
-         geovar_geomz: geopotential_height
-       linear obs operator:
-         name: Identity
- 
-       obs error:
-         covariance model: diagonal
- 
-       obs pre filters:
-       - filter: Domain Check
-         apply at iterations: 0,1
-         where:
-         - variable:
-             name: MetaData/latitude
-           minvalue: {{MIN_LAT}}
-           maxvalue: {{MAX_LAT}}
-         action:
-           name: reduce obs space
- 
-       - filter: Domain Check
-         apply at iterations: 0,1
-         where:
-         - variable:
-             name: MetaData/longitude
-           minvalue: {{MIN_LON}}
-           maxvalue: {{MAX_LON}}
-         action:
-           name: reduce obs space
- 
-       # Reject all obs with QualityMarker > 3
-       - filter: RejectList
-         apply at iterations: 0,1
-         filter variables:
-         - name: stationPressure
-         where:
-         - variable: ObsType/stationPressure
-           is_not_in: 120
-         - variable: QualityMarker/stationPressure
-           is_in: 4-15
-           value: is_not_valid
-         - variable: MetaData/pressure
-           value: is_not_valid
-         where operator: or
-         action:
-           name: reduce obs space
- 
-       obs post filters:
-       - filter: Bounds Check
-         filter variables:
-         - name: stationPressure
-         test variables:
-         - name: GeoVaLs/observable_domain_mask
-           flag all filter variables if any test variable is out of bounds: true
-           minvalue: 0.0
-           maxvalue: 0.5
-       # ------------------
-       # stationPressure
-       # ------------------
-       # Initial error assignment
-       # 120
-       - filter: Perform Action
-         filter variables:
-         - name: stationPressure
-         where:
-         - variable: ObsType/stationPressure
-           is_in: 120
-         action:
-           name: assign error
-           error parameter: 68.115 #Pa
-           #error function:
-           #  name: ObsFunction/ObsErrorModelStepwiseLinear
-           #  options:
-           #    xvar:
-           #      name: MetaData/pressure
-           #    xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
-           #    errors: [68.115, 68.115, 68.115, 71.307, 74.576, 77.845, 79.791, 81.737, 83.684, 92.441, 101.2, 108.99, 117.75, 128.44, 144.99, 158.58, 182.93, 247.16, 269.54, 315.28, 383.38, 489.46, 577.03, 577.03, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0]
-         defer to post: true
- 
-       ## Ajusted error after initial assignment (qcmod.f90)
-       #- filter: Perform Action
-       #  filter variables:
-       #  - name: stationPressure
-       #  where:
-       #  - variable: ObsType/stationPressure
-       #    is_in: 120
-       #  action:
-       #    name: inflate error
-       #    inflation variable:
-       #      name: ObsFunction/ObsErrorFactorConventional
-       #      options:
-       #        test QCflag: PreQC
-       #        test QCthreshold: 3
-       #        inflate variables: [stationPressure]
-       #        pressure: MetaData/pressure
-       #        distance threshold: -1.
-       #  defer to post: true
- 
-       # error inflation based on setupps.f90
-       - filter: Perform Action
-         filter variables:
-         - name: stationPressure
-         where:
-         - variable: ObsType/stationPressure
-           is_in: 120
-         action:
-           name: inflate error
-           #inflation factor: 1.7143
-           inflation variable:
-             name: ObsFunction/ObsErrorFactorSfcPressure
-         defer to post: true
- 
-       - filter: Bounds Check
-         apply at iterations: 0,1
-         filter variables:
-         - name: stationPressure
-         minvalue: 0.0
-         maxvalue: 120000.0
- 
-       - filter: Background Check
-         apply at iterations: 0,1
-         filter variables:
-         - name: stationPressure
-         #absolute threshold: 5.0
-         threshold: 5.0
-         where:
-         - variable: ObsType/stationPressure
-           is_in: 120
-         action:
-           name: reject
- 
-       ##- filter: Domain Check
-       #  apply at iterations: 0,1
-       #  where:
-       #    - variable:
-       #        name: MetaData/timeOffset
-       #      minvalue: -1.50
-       #      maxvalue: 1.50
- 
-       - filter: Temporal Thinning
-         apply at iterations: 0,1
-         min_spacing: PT00M
-         seed_time: "{{atmosphere_background_time_iso6}}"
-         category_variable:
-           name: MetaData/stationIdentification
- 
-       ## Print filter data
-       #- filter: Print Filter Data
-       #  message: Printing filter data
-       #  summary: true
-       #  variables:
-       #  - variable: MetaData/latitude
-       #  - variable: MetaData/longitude
-       #  - variable: MetaData/pressure
-       #  - variable: ObsType/stationPressure
-       #  - variable: ObsValue/stationPressure
-       #  - variable: QCflagsData/stationPressure
+    - obs space:
+        name: adpupa_stationPressure_120
+        obsdatain:
+          engine:
+            type: H5File
+            obsfile: obs/hafs.t{{HH}}z.conventional_air_raob.nc
+            missing file action: warn
+          obsgrouping:
+            group variables:
+            - stationIdentification
+            sort variable: pressure
+            sort order: descending
+        obsdataout:
+          engine:
+            type: H5File
+            obsfile: hofx/diag_conventional_air_raobps_t{{HH}}z.nc
+            allow overwrite: true
+        io pool:
+          max pool size: {{TOTAL_TASKS}}
+        observed variables: [stationPressure]
+        simulated variables: [stationPressure]
+
+      obs operator:
+        name: SfcCorrected
+        variables:
+        - name: stationPressure
+        correction scheme to use: GSL
+        station_altitude: height
+        geovar_sfc_geomz: height_above_mean_sea_level_at_surface
+        geovar_geomz: geopotential_height
+
+      linear obs operator:
+        name: Identity
+        variables:
+        - name: stationPressure
+
+      obs error:
+        covariance model: diagonal
+
+      obs pre filters:
+      - filter: Domain Check
+        apply at iterations: 0, 1
+        where:
+        - variable:
+            name: MetaData/latitude
+          minvalue: {{MIN_LAT}}
+          maxvalue: {{MAX_LAT}}
+        action:
+          name: reduce obs space
+      - filter: Domain Check
+        apply at iterations: 0, 1
+        where:
+        - variable:
+            name: MetaData/longitude
+          minvalue: {{MIN_LON}}
+          maxvalue: {{MAX_LON}}
+        action:
+          name: reduce obs space
+      # Reject all obs with QualityMarker > 3
+      - filter: RejectList
+        apply at iterations: 0,1
+        filter variables:
+        - name: stationPressure
+        where:
+        - variable: ObsType/stationPressure
+          is_not_in: 120
+        - variable: QualityMarker/stationPressure
+          is_in: 4-15
+          value: is_not_valid
+        - variable: MetaData/pressure
+          value: is_not_valid
+        where operator: or
+        action:
+          name: reduce obs space
+
+      obs prior filters:
+      - filter: Bounds Check
+        filter variables:
+        - name: stationPressure
+        test variables:
+        - name: GeoVaLs/observable_domain_mask
+          flag all filter variables if any test variable is out of bounds: true
+          minvalue: 0.0
+          maxvalue: 0.5
+
+      - filter: Perform Action
+        filter variables:
+        - name: stationPressure
+        where:
+        - variable: ObsType/stationPressure
+          is_in: 120
+        action:
+          name: assign error
+          error function:
+            name: ObsFunction/ObsErrorModelStepwiseLinear
+            options:
+              xvar:
+                name: ObsValue/stationPressure
+              xvals: [110000, 105000, 100000, 95000, 90000, 85000, 80000, 75000, 70000, 65000, 60000, 55000, 50000, 45000, 40000, 35000, 30000, 25000, 20000, 15000, 10000, 7500, 5000, 4000, 3000, 2000, 1000, 500, 400, 300, 200, 100, 0]
+              errors: [76.322, 76.322, 76.322, 79.899, 83.56099999999999, 87.224, 89.405, 91.58500000000001, 93.767, 103.58000000000001, 113.38999999999999, 122.12, 131.94, 143.91, 162.46, 177.69, 204.97, 276.94, 302.02, 353.27000000000004, 429.57, 548.4399999999999, 646.55, 646.55, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0, 100000000000.0]
+      # Create PreQC group Variable
+      - filter: Variable Assignment
+        assignments:
+        - name: InputObsError/stationPressure
+          type: float
+          source variable: ObsError/stationPressure
+
+      # Create PreUseFlag Group Variable
+      - filter: Variable Assignment
+        assignments:
+        - name: PreUseFlag/stationPressure
+          type: int
+          source variable: QualityMarker/stationPressure
+      - filter: Variable Assignment
+        where:
+        - variable:
+            name: PreUseFlag/stationPressure
+          is_in: 1-15
+        assignments:
+        - name: PreUseFlag/stationPressure
+          value: 0
+      - filter: Variable Assignment
+        where:
+        - variable:
+            name: ObsValue/stationPressure
+          is_defined: null
+        - variable:
+            name: ObsValue/stationPressure
+          maxvalue: 50000.0
+        where operator: and
+        assignments:
+        - name: PreUseFlag/stationPressure
+          value: 100
+      - filter: Variable Assignment
+        where:
+        - variable:
+            name: QualityMarker/stationPressure
+          is_in: 9, 12, 15
+        assignments:
+        - name: PreUseFlag/stationPressure
+          value: 100
+      - filter: Variable Assignment
+        where:
+        - variable:
+            name: QualityMarker/stationPressure
+          is_in: 4-15
+        assignments:
+        - name: PreUseFlag/stationPressure
+          value: 101
+      # Inflate obs error based on obs type
+      - filter: Perform Action
+        filter variables:
+        - name: stationPressure
+        action:
+          name: inflate error
+          inflation factor: 1.2
+        where:
+        - variable: QualityMarker/stationPressure
+          is_in: 3, 7
+
+      # Observation Post Filters (QC)
+      # ----------------------------------------
+      obs post filters:
+      # Calculate the obs error inflation factors for duplicated observations at the same location
+      - filter: Variable Assignment
+        assignments:
+        - name: ObsErrorFactorDuplicateCheck/stationPressure
+          type: float
+          function:
+            name: ObsFunction/ObsErrorFactorDuplicateCheck
+            options:
+              use_air_pressure: false
+              variable: stationPressure
+      # Inflate surface pressure observation based on discrepancies between model and observations due to terrain
+      - filter: Perform Action
+        filter variables:
+        - name: stationPressure
+        where:
+        - variable: ObsType/airTemperature
+          is_in: 120
+        action:
+          name: inflate error
+          inflation variable:
+            name: ObsFunction/ObsErrorFactorSfcPressure
+            options:
+              geovar_sfc_geomz: height_above_mean_sea_level_at_surface
+              geovar_geomz: geopotential_height
+              station_altitude: height
+
+      - filter: Variable Assignment
+        assignments:
+        - name: DerivedMetaData/Innovation
+          type: float
+          function:
+            name: ObsFunction/Arithmetic
+            options:
+              variables:
+              - name: ObsValue/stationPressure
+              - name: HofX/stationPressure
+              coefs:
+              - 1
+              - -1
+      - filter: Variable Assignment
+        assignments:
+        - name: DerivedMetaData/ObsErrorBoundSfcPressure1
+          type: float
+          function:
+            name: ObsFunction/ObsErrorBoundConventional
+            options:
+              obsvar: stationPressure
+              obserr_bound_min: 100
+              obserr_bound_max: 300
+              obserr_bound_factor: 4.0
+
+      - filter: Background Check
+        filter variables:
+        - name: stationPressure
+        where:
+        - variable: QualityMarker/stationPressure
+          is_not_in: 3
+          value: is_not_valid
+        where operator: or
+        function absolute threshold:
+        - name: DerivedMetaData/ObsErrorBoundSfcPressure1
+        action:
+          name: reject
+      - filter: Variable Assignment
+        assignments:
+        - name: DerivedMetaData/ObsErrorBoundSfcPressure2
+          type: float
+          function:
+            name: ObsFunction/ObsErrorBoundConventional
+            options:
+              obsvar: stationPressure
+              obserr_bound_min: 100
+              obserr_bound_max: 300
+              obserr_bound_factor: 2.8
+
+      - filter: Background Check
+        filter variables:
+        - name: stationPressure
+        where:
+        - variable: QualityMarker/stationPressure
+          is_in: 3
+          value: is_not_valid
+        where operator: or
+        function absolute threshold:
+        - name: DerivedMetaData/ObsErrorBoundSfcPressure2
+        action:
+          name: reject
+      # Inflate obs error based on duplicate check
+      - filter: Perform Action
+        filter variables:
+        - name: stationPressure
+        action:
+          name: inflate error
+          inflation variable:
+            name: ObsErrorFactorDuplicateCheck/stationPressure
+      - filter: Perform Action
+        filter variables:
+        - name: stationPressure
+        where:
+        - variable: PreUseFlag/stationPressure
+          is_not_in: 0, 1
+          value: is_not_valid
+        where operator: or
+        action:
+          name: reject
+


### PR DESCRIPTION
This PR updated the sondes obs processing yaml, python scripts and the fv3jedi yaml for stationPressure otyp 120. 
Details can be find in #77 

Meanwhile, a fix was made in the `ascatw` bufr-query python to correct the mapping YAML file name called within the script.